### PR TITLE
updated all dependencies to latest versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ plugins {
     id 'idea'
 }
 
-def playVersion = '2.6.19'
-def scalaVersion = System.getProperty("scala.binary.version", /* default = */ "2.12")
+def playVersion = '2.8.16'
+def scalaVersion = System.getProperty("scala.binary.version", /* default = */ "2.13")
 
 model {
     components {

--- a/build.sbt
+++ b/build.sbt
@@ -5,16 +5,21 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.13.8"
 
 libraryDependencies += guice
-libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test
+libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test
 
+val jwtScalaVersion = "9.1.1"
 libraryDependencies ++= Seq(
-  "com.pauldijou" %% "jwt-play" % "0.19.0",
-  "com.pauldijou" %% "jwt-core" % "0.19.0",
-  "com.auth0" % "jwks-rsa" % "0.6.1"
+  "com.github.jwt-scala" %% "jwt-play" % jwtScalaVersion,
+  "com.github.jwt-scala" %% "jwt-core" % jwtScalaVersion,
+  "com.auth0" % "jwks-rsa" % "0.21.2"
 )
+
+// Workaround for https://github.com/jwt-scala/jwt-scala/issues/403
+dependencyOverrides += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.11.4"
+dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.11.1"
 
 // Adds additional packages into Twirl
 //TwirlKeys.templateImports += "com.example.controllers._"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.7.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.16")


### PR DESCRIPTION
- All dependencies have been updated to latest versions
- Uses Scala 2.13.8
- Uses sbt 1.7.1
- `jwt-scala` has moved to `com.github.jwt-scala`, and the API now requires a implicit `clock: java.time.Clock` parameter to check for token expiration.  Accordingly, `AuthService` now injects a `Provider[Clock]`.
